### PR TITLE
skip selecting columns from .tbl in negate_select_cols

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Roxygen: list(markdown = TRUE)
 Imports: keyholder,
     dplyr (>= 0.7.0),
     rlang,
-    tidyr (>= 0.7.0)
+    tidyr (>= 0.7.0),
+    tidyselect (>= 0.2.3)
 Suggests: knitr,
     rmarkdown,
     testthat,

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,9 +21,9 @@ inside_punct <- function(.x = "\\._\\.") {
 }
 
 negate_select_cols <- function(.tbl, ...) {
-  selected_tbl <- select(.tbl, ...)
-
-  setdiff(colnames(.tbl), colnames(selected_tbl))
+  nms <- colnames(.tbl)
+  skip_names <- tidyselect::vars_select(nms, ...)
+  setdiff(nms, skip_names)
 }
 
 


### PR DESCRIPTION
I have just changed a few lines here--this PR should let us avoid creating `selected_tbl`.  We can do this since all we are interested in here is the names.  Here is a discussion of a similar task: https://community.rstudio.com/t/tidiest-way-to-quote-bare-names-in-dots-with-rlang/2118/7.